### PR TITLE
add lineBreak class and implement on art description

### DIFF
--- a/src/components/ArtInfo.js
+++ b/src/components/ArtInfo.js
@@ -11,6 +11,9 @@ const useStyles = makeStyles(theme => ({
   space: {
     padding: theme.spacing(3),
   },
+  lineBreak: {
+    whiteSpace: 'pre-line'
+  },
 }))
 
 const ArtInfo = ({ info }) => {
@@ -26,7 +29,7 @@ const ArtInfo = ({ info }) => {
             Artist: {info.artist_name}
           </Typography>
           <Typography variant='h3'>{info.category.category}</Typography>
-          <Typography variant='h3'>
+          <Typography variant='h3' className={classes.lineBreak}>
             {info.description === ''
               ? 'No description available'
               : info.description}


### PR DESCRIPTION
# Description

Fix to have line breaks added by a user respected in the art listing description.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Manually via viewing the content of an art listing with line breaks in the description.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
