### PR TITLE
set title of art piece into subject for form to be included with email

### DIFF
--- a/src/components/forms/Contact.js
+++ b/src/components/forms/Contact.js
@@ -33,7 +33,7 @@ const Contact = props => {
   const [sendto] = useState(props.info.email)
   const [name, setName] = useState('')
   const [fromUser, setFromUser] = useState('')
-  const [subject, setSubject] = useState('')
+  const [subject, setSubject] = useState(`Purchasing ${props.artListing.title}`)
   const [message, setMessage] = useState('')
   const classes = formStyles()
 
@@ -101,7 +101,7 @@ const Contact = props => {
                 size='small'
                 type='text'
                 required
-                value={subject}
+                value={props.artListing.title === '' ? 'Purchasing Untitled' : subject}
                 onChange={e => setSubject(e.target.value)}
               />
             </Grid>

--- a/src/views/SinglePage.js
+++ b/src/views/SinglePage.js
@@ -98,7 +98,7 @@ const SinglePage = props => {
           </CardActions>
           <Collapse in={expanded} timeout='auto' unmountOnExit>
             <CardContent>
-              <Contact info={data.art.school} />
+              <Contact info={data.art.school} artListing={data.art} />
             </CardContent>
           </Collapse>
         </Card>


### PR DESCRIPTION
# Description

I adjusted it so that the title of the Art Piece is included in the subject of the Contact form by default. This also takes into account when an art piece doesn't have a title and will call it Untitled as we do in the `ArtInfo` component. This way the buyer will have a good default subject that will let the seller know what piece they are talking about in case the buyer doesn't mention it in the email.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Tested manually in my local environment.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
